### PR TITLE
Fix error: missing user_nonce table

### DIFF
--- a/ocean_provider/user_nonce.py
+++ b/ocean_provider/user_nonce.py
@@ -26,6 +26,13 @@ class UserNonce:
 
 class NonceStorage(StorageBase):
     TABLE_NAME = 'user_nonce'
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._run_query(
+            f'''CREATE TABLE IF NOT EXISTS {self.TABLE_NAME}
+               (address VARCHAR PRIMARY KEY , nonce VARCHAR);'''
+        ) 
 
     def write_nonce(self, address, nonce):
         """
@@ -36,10 +43,6 @@ class NonceStorage(StorageBase):
         """
         logger.debug(f'Writing nonce value to {self.TABLE_NAME} storage: '
                      f'account={address}, nonce={nonce}')
-        self._run_query(
-            f'''CREATE TABLE IF NOT EXISTS {self.TABLE_NAME}
-               (address VARCHAR PRIMARY KEY , nonce VARCHAR);'''
-        )
         self._run_query(
             f'''INSERT OR REPLACE
                 INTO {self.TABLE_NAME}


### PR DESCRIPTION
Fix for the following error:
```
2020-09-09 03:54:02 aed285c539cc root[10] ERROR Error reading nonce value for account 0xa0041f95646640DBB8f3f43a96b00C1B27E7596e: no such table: user_nonce
```

It is trying to read nonce before the table is created.